### PR TITLE
Add BEAR.Sunday code quality and development skills

### DIFF
--- a/.claude/skills/bear-cache-strategy/SKILL.md
+++ b/.claude/skills/bear-cache-strategy/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: bear-cache-strategy
+description: リソースクラスを走査し、キャッシュ属性を追加する。キャッシュ宣言がないリソースを検出して適切な属性を適用。
+---
+
+# BEAR.Sunday キャッシュ属性追加スキル
+
+## 目的
+
+キャッシュ宣言がないリソースを検出し、適切なキャッシュ属性を追加する。
+
+## 実行手順
+
+### 1. キャッシュ未宣言リソースを検出
+
+```bash
+# onGetがあるがCacheableがないファイルを検出
+grep -rl "function onGet" src/Resource | xargs grep -L "Cacheable"
+```
+
+### 2. 各リソースを分類
+
+リソースを読み、以下を判定:
+- コンテンツAPI → `#[Cacheable]`
+- 計算API → `#[Cacheable(expirySecond: N)]`
+- キャッシュ不可 → コメントで理由明示
+
+### 3. キャッシュ属性を追加
+
+```php
+use BEAR\RepositoryModule\Annotation\Cacheable;
+
+#[Cacheable]
+public function onGet(int $id): static
+```
+
+## リソースの分類
+
+### コンテンツAPI（キャッシュ可能）
+
+データの取得・表示が主目的。同じ入力には同じ出力。
+
+| 特徴 | 例 |
+|------|-----|
+| 記事、ページ | Article, Page, Post |
+| 一覧表示 | Articles, List, Index |
+| マスタデータ | Category, Tag, User |
+| 静的コンテンツ | About, Help, Guide |
+
+**適用属性:**
+```php
+#[Cacheable]
+#[CacheableResponse(maxAge: 3600)]
+#[DonutCache]  // 部分キャッシュ
+```
+
+### 計算API（キャッシュ不可/短時間）
+
+リアルタイム性が必要、または副作用がある。
+
+| 特徴 | 例 |
+|------|-----|
+| リアルタイムデータ | Stock, Rate, Weather |
+| ユーザー固有 | Cart, Session, Preference |
+| 集計・計算 | Analytics, Report, Stats |
+| 書き込み操作 | POST/PUT/DELETE |
+
+**適用属性:**
+```php
+#[Cacheable(expirySecond: 60)]  // 短時間キャッシュ
+// または属性なし（キャッシュしない）
+```
+
+## 判定フロー
+
+```
+リソースクラスを読む
+    ↓
+onGet のみ？ ─No→ キャッシュしない（書き込み操作）
+    ↓ Yes
+外部API依存？ ─Yes→ 短時間キャッシュ or キャッシュしない
+    ↓ No
+ユーザー固有？ ─Yes→ キャッシュしない or Vary: Cookie
+    ↓ No
+時間依存？ ─Yes→ 短時間キャッシュ
+    ↓ No
+コンテンツAPI → #[Cacheable] 適用
+```
+
+## 適用手順
+
+### 1. リソースを走査して分類
+
+```php
+// 分類結果
+$contentApis = [
+    'App\Resource\App\Article',      // 記事
+    'App\Resource\App\Category',     // カテゴリ
+    'App\Resource\Page\Index',       // トップページ
+];
+
+$computationApis = [
+    'App\Resource\App\Cart',         // カート（ユーザー固有）
+    'App\Resource\App\Search',       // 検索（パラメータ多様）
+    'App\Resource\App\Analytics',    // 集計（リアルタイム）
+];
+```
+
+### 2. コンテンツAPIにキャッシュ属性を追加
+
+```php
+use BEAR\RepositoryModule\Annotation\Cacheable;
+
+#[Cacheable]
+class Article extends ResourceObject
+{
+    public function onGet(int $id): static
+}
+```
+
+### 3. 計算APIは短時間または無効
+
+```php
+// 短時間キャッシュ（60秒）
+#[Cacheable(expirySecond: 60)]
+class Ranking extends ResourceObject
+
+// キャッシュなし（属性なし）
+class Cart extends ResourceObject
+```
+
+## キャッシュ戦略の選択
+
+### #[Cacheable] - 依存が明確なリソース
+
+予測可能性が高く、依存関係が明らかなリソースに使用。
+
+```php
+// ✅ 適用: 依存が明確（記事IDのみに依存）
+#[Cacheable]
+public function onGet(int $id): static
+
+// ✅ 適用: ETagで自動無効化
+#[Cacheable]
+#[Embed(rel: 'author', src: 'app://self/user{?id}')]
+public function onGet(int $id): static
+```
+
+**適用条件:**
+- 入力パラメータのみに依存
+- 時間に依存しない
+- 外部状態に依存しない
+- Embedの依存も自動追跡される
+
+### #[DonutCache] - 部分的に動的なページ
+
+ページの大部分はキャッシュ可能だが、一部が動的（ユーザー情報等）。
+
+```php
+// Pageリソース: 全体をドーナッツキャッシュ
+#[DonutCache]
+#[Embed(rel: 'article', src: 'app://self/article{?id}')]      // キャッシュされる
+#[Embed(rel: 'sidebar', src: 'app://self/sidebar')]           // キャッシュされる
+#[Embed(rel: 'user_menu', src: 'app://self/user/menu')]       // 動的（穴）
+public function onGet(int $id): static
+```
+
+```
+┌─────────────────────────────┐
+│  ヘッダー（キャッシュ）      │
+├─────────────────────────────┤
+│  記事本文（キャッシュ）      │
+│                             │
+│  ┌─────────────────────┐   │
+│  │ ユーザーメニュー     │   │  ← ドーナッツの穴（動的）
+│  │ （毎回取得）         │   │
+│  └─────────────────────┘   │
+│                             │
+│  サイドバー（キャッシュ）    │
+└─────────────────────────────┘
+```
+
+### #[CacheableResponse] - CDN/ブラウザキャッシュ
+
+HTTPレスポンスレベルでキャッシュ。CDNやブラウザに指示。
+
+```php
+#[CacheableResponse(maxAge: 3600, sMaxAge: 86400)]
+public function onGet(int $id): static
+// Cache-Control: max-age=3600, s-maxage=86400
+```
+
+### #[Cacheable(expirySecond: N)] - TTLが明確な計算API
+
+計算APIでも更新頻度がわかればキャッシュ可能。
+
+```php
+// ランキング: 5分ごとに更新で十分
+#[Cacheable(expirySecond: 300)]
+public function onGet(): static
+
+// 為替レート: 1分で十分
+#[Cacheable(expirySecond: 60)]
+public function onGet(string $currency): static
+
+// 天気: 10分で十分
+#[Cacheable(expirySecond: 600)]
+public function onGet(string $city): static
+```
+
+**TTL判定の質問:**
+- このデータは何秒古くても許容される？
+- 更新頻度はどのくらい？
+- ユーザーは古いデータに気づく？
+
+| リソース | 許容遅延 | TTL例 |
+|---------|---------|-------|
+| ランキング | 5分 | 300 |
+| 為替レート | 1分 | 60 |
+| 天気 | 10分 | 600 |
+| 在庫数 | 30秒 | 30 |
+| ニュース一覧 | 1分 | 60 |
+
+### キャッシュなし - 本当に予測不能なリソース
+
+```php
+// キャッシュしない: ユーザー固有、セッション依存
+public function onGet(): static  // 属性なし
+```
+
+**キャッシュ不可の条件:**
+- ユーザーセッションに依存
+- リアルタイム性が絶対必要（チャット等）
+- 書き込み操作（POST/PUT/DELETE）
+
+### キャッシュ宣言がないリソース = 問題
+
+キャッシュ属性が何もないのは「考慮漏れ」。すべてのGETリソースはキャッシュ戦略を明示すべき。
+
+```php
+// ❌ 問題: キャッシュ宣言なし（考慮漏れ）
+public function onGet(int $id): static
+
+// ✅ 推奨: 明示的にキャッシュ
+#[Cacheable]
+public function onGet(int $id): static
+
+// ✅ 推奨: 明示的にTTL指定
+#[Cacheable(expirySecond: 300)]
+public function onGet(): static
+
+// ✅ 推奨: キャッシュ不可なら #[NoCache] や コメントで明示
+/** @note キャッシュ不可: ユーザーセッションに依存 */
+public function onGet(): static
+```
+
+**レビュー時のチェック:**
+- onGetメソッドにキャッシュ属性があるか？
+- なければ理由が明示されているか？
+
+## 判定マトリクス
+
+| 条件 | キャッシュ戦略 |
+|------|---------------|
+| 依存が明確 + 時間非依存 | `#[Cacheable]` |
+| ページ全体は静的、一部動的 | `#[DonutCache]` |
+| CDN/ブラウザでキャッシュ | `#[CacheableResponse]` |
+| 許容遅延が明確 | `#[Cacheable(expirySecond: N)]` |
+| ユーザー固有/セッション依存 | キャッシュなし |
+
+## 判定フロー
+
+```
+リソースを分析
+    ↓
+書き込み操作？ ─Yes→ キャッシュ不可
+    ↓ No
+ユーザー固有？ ─Yes→ キャッシュ不可
+    ↓ No
+依存が明確？ ─Yes→ #[Cacheable]
+    ↓ No
+許容遅延がある？ ─Yes→ #[Cacheable(expirySecond: N)]
+    ↓ No
+キャッシュ不可
+```
+
+## キャッシュ無効化
+
+| 属性 | タイミング | 動作 |
+|------|-----------|------|
+| `#[Purge]` | PUT/DELETE時 | キャッシュ削除 |
+| `#[Refresh]` | PUT時 | 再生成して更新 |
+
+## 出力例
+
+```
+## キャッシュ戦略レポート
+
+### コンテンツAPI（#[Cacheable]適用推奨）
+- src/Resource/App/Article.php
+- src/Resource/App/Category.php
+- src/Resource/Page/Index.php
+- src/Resource/Page/Article.php
+
+### 計算API（キャッシュなしまたは短時間）
+- src/Resource/App/Cart.php - ユーザー固有
+- src/Resource/App/Search.php - パラメータ多様
+- src/Resource/App/Ranking.php - #[Cacheable(expirySecond: 300)]推奨
+
+### 書き込みAPI（キャッシュ不可）
+- src/Resource/App/Article.php (onPost, onPut, onDelete)
+```
+
+## 参考資料
+
+- [BEAR.Sunday キャッシュ](https://bearsunday.github.io/manuals/1.0/ja/cache.html)

--- a/.claude/skills/bear-cache-strategy/SKILL.md
+++ b/.claude/skills/bear-cache-strategy/SKILL.md
@@ -73,7 +73,7 @@ public function onGet(int $id): static
 
 ## 判定フロー
 
-```
+```text
 リソースクラスを読む
     ↓
 onGet のみ？ ─No→ キャッシュしない（書き込み操作）
@@ -165,7 +165,7 @@ public function onGet(int $id): static
 public function onGet(int $id): static
 ```
 
-```
+```text
 ┌─────────────────────────────┐
 │  ヘッダー（キャッシュ）      │
 ├─────────────────────────────┤
@@ -268,9 +268,9 @@ public function onGet(): static
 | 許容遅延が明確 | `#[Cacheable(expirySecond: N)]` |
 | ユーザー固有/セッション依存 | キャッシュなし |
 
-## 判定フロー
+## 戦略選択フロー
 
-```
+```text
 リソースを分析
     ↓
 書き込み操作？ ─Yes→ キャッシュ不可
@@ -293,7 +293,7 @@ public function onGet(): static
 
 ## 出力例
 
-```
+```markdown
 ## キャッシュ戦略レポート
 
 ### コンテンツAPI（#[Cacheable]適用推奨）

--- a/.claude/skills/bear-hypermedia/SKILL.md
+++ b/.claude/skills/bear-hypermedia/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: bear-hypermedia
+description: リソースクラスに#[Link]を追加し、HyperMediaテストでユースケースを表現する。API設計改善時に使用。
+---
+
+# BEAR.Sunday ハイパーメディア実装スキル
+
+## 目的
+
+1. リソースクラスに `#[Link]` を追加して遷移可能なアクションを宣言
+2. HyperMediaテストでユースケース（ワークフロー）を表現
+
+## 手順
+
+### 1. リソースクラスの分析
+
+リソースを読み、可能なアクションを特定:
+
+- 編集できる → `rel: 'edit'`
+- 削除できる → `rel: 'delete'`
+- 詳細がある → `rel: 'item'`
+- 一覧に戻れる → `rel: 'collection'`
+- 次/前がある → `rel: 'next'` / `rel: 'prev'`
+
+### 2. #[Link]の追加
+
+```php
+use BEAR\Resource\Annotation\Link;
+
+#[Link(rel: 'edit', href: '/article/{id}/edit')]
+#[Link(rel: 'delete', href: '/article/{id}', method: 'delete')]
+#[Link(rel: 'comments', href: '/article/{id}/comments')]
+public function onGet(int $id): static
+```
+
+### 3. HyperMediaテストの実装
+
+ユースケースをテストで表現:
+
+```php
+/**
+ * 記事編集ワークフロー
+ *
+ * [記事一覧] --item--> [記事詳細] --edit--> [編集] --update--> [記事詳細]
+ */
+public function testArticleEditWorkflow(): void
+{
+    // 記事一覧を取得
+    $articles = $this->resource->get('app://self/articles');
+
+    // 最初の記事の詳細へ遷移
+    $article = $this->resource->href('item', $articles);
+    $this->assertSame(200, $article->code);
+
+    // 編集へ遷移
+    $edit = $this->resource->href('edit', $article);
+    $this->assertSame(200, $edit->code);
+
+    // 更新を実行
+    $updated = $this->resource->href('update', $edit, ['title' => 'New Title']);
+    $this->assertSame(200, $updated->code);
+}
+```
+
+## ユースケース例
+
+### 記事管理
+
+```
+[記事一覧] --item--> [記事詳細] --edit--> [編集フォーム] --update--> [記事詳細]
+                         |
+                         +--delete--> [記事一覧]
+                         |
+                         +--comments--> [コメント一覧]
+```
+
+### ユーザー登録
+
+```
+[トップ] --signup--> [登録フォーム] --create--> [確認] --verify--> [完了]
+```
+
+## リソースクラスからALPS生成
+
+リソースクラスを分析してALPSプロファイルを生成する。
+
+### マッピング
+
+| BEAR.Sunday | ALPS |
+|-------------|------|
+| リソースクラス | State（状態） |
+| `#[Link(rel, href)]` | Transition（遷移） |
+| `#[Embed(rel, src)]` | 埋め込み状態 |
+| メソッド引数 | Semantic descriptor |
+| onGet | safe transition |
+| onPost | unsafe transition |
+| onPut/onDelete | idempotent transition |
+
+### 生成手順
+
+1. リソースクラスを読む
+2. クラス名 → State ID
+3. `#[Link]` → Transition（relからgo/do判定）
+4. `#[Embed]` → 埋め込み参照
+5. 引数 → Semantic descriptor
+6. ALPSスキルで生成・検証
+
+### 例: ArticleリソースからALPS
+
+```php
+// Resource
+#[Link(rel: 'edit', href: '/article/{id}/edit')]
+#[Link(rel: 'delete', href: '/article/{id}', method: 'delete')]
+#[Embed(rel: 'author', src: 'app://self/user{?id}')]
+#[Embed(rel: 'comments', src: 'app://self/article/{id}/comments')]
+public function onGet(int $id): static
+```
+
+↓ 生成
+
+```json
+{
+  "id": "ArticleDetail",
+  "title": "Article Detail",
+  "descriptor": [
+    {"href": "#articleId"},
+    {"href": "#Author"},
+    {"href": "#Comments"},
+    {"href": "#goEdit"},
+    {"href": "#doDelete"}
+  ]
+}
+```
+
+### ALPSスキルとの連携
+
+生成後は `/alps` スキルで:
+- 検証: `asd --validate profile.json`
+- 図生成: `asd profile.json`
+- 改善提案を取得
+
+## 参考資料
+
+- [BEAR.Sunday リソース](https://bearsunday.github.io/manuals/1.0/ja/resource.html)
+- [BEAR.Sunday テスト](https://bearsunday.github.io/manuals/1.0/ja/test.html)
+- [ALPS Specification](http://alps.io/spec/)

--- a/.claude/skills/bear-resource-test/SKILL.md
+++ b/.claude/skills/bear-resource-test/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: bear-resource-test
+description: リソースクラスを読んでスモークテストのdataProviderを生成する。全リソースを1つのテストクラスでテスト。
+---
+
+# BEAR.Sunday リソーステスト生成スキル
+
+## 目的
+
+リソースクラスを分析し、スモークテスト用のdataProviderを生成する。
+
+## テスト構造
+
+```php
+class ResourceTest extends TestCase
+{
+    use ResourceTestTrait;
+
+    /**
+     * @dataProvider resourceProvider
+     */
+    public function testResource(string $method, string $uri, array $query, int $expectedCode): void
+    {
+        $response = $this->resource->{$method}($uri, $query);
+        $this->assertSame($expectedCode, $response->code);
+    }
+
+    public static function resourceProvider(): array
+    {
+        return [
+            // 生成されたテストケース
+            'GET /article' => ['get', 'app://self/article', ['id' => 1], 200],
+            'GET /articles' => ['get', 'app://self/articles', [], 200],
+            'POST /article' => ['post', 'app://self/article', ['title' => 'Test', 'body' => 'Content'], 201],
+            // ...
+        ];
+    }
+}
+```
+
+## 生成手順
+
+### 1. リソースクラスを分析
+
+```php
+// 入力: src/Resource/App/Article.php
+public function onGet(int $id): static
+public function onPost(string $title, string $body): static
+public function onDelete(int $id): static
+```
+
+### 2. テストケースを抽出
+
+| メソッド | URI | 必須パラメータ | 期待コード |
+|---------|-----|---------------|-----------|
+| GET | app://self/article | id | 200 |
+| POST | app://self/article | title, body | 201 |
+| DELETE | app://self/article | id | 204 |
+
+### 3. dataProviderに追加
+
+```php
+'GET /article' => ['get', 'app://self/article', ['id' => 1], 200],
+'POST /article' => ['post', 'app://self/article', ['title' => 'Test', 'body' => 'Body'], 201],
+'DELETE /article' => ['delete', 'app://self/article', ['id' => 1], 204],
+```
+
+## パラメータのデフォルト値
+
+| 型 | デフォルト値 |
+|----|-------------|
+| int | 1 |
+| string | 'test' |
+| bool | true |
+| array | [] |
+| ?type | null |
+
+## 期待コードの判定
+
+| メソッド | デフォルトコード |
+|---------|-----------------|
+| onGet | 200 |
+| onPost | 201 |
+| onPut | 200 |
+| onPatch | 200 |
+| onDelete | 204 |
+
+## 使い方
+
+1. リソースディレクトリを指定
+2. スキルがリソースクラスを走査
+3. dataProviderのPHPコードを生成
+4. 既存テストに追加または新規作成
+
+## 出力例
+
+```php
+public static function resourceProvider(): array
+{
+    return [
+        // App resources
+        'GET app://self/article (id)' => ['get', 'app://self/article', ['id' => 1], 200],
+        'GET app://self/articles' => ['get', 'app://self/articles', [], 200],
+        'GET app://self/articles (limit)' => ['get', 'app://self/articles', ['limit' => 10], 200],
+        'POST app://self/article' => ['post', 'app://self/article', ['title' => 'test', 'body' => 'test'], 201],
+        'DELETE app://self/article' => ['delete', 'app://self/article', ['id' => 1], 204],
+
+        // Page resources
+        'GET page://self/index' => ['get', 'page://self/index', [], 200],
+        'GET page://self/article' => ['get', 'page://self/article', ['id' => 1], 200],
+    ];
+}
+```
+
+## 注意事項
+
+- 認証が必要なリソースは別途設定が必要
+- 外部依存のあるリソースはモックが必要な場合あり
+- 生成後に手動でパラメータ値を調整

--- a/.claude/skills/bear-review/SKILL.md
+++ b/.claude/skills/bear-review/SKILL.md
@@ -1,0 +1,738 @@
+---
+name: bear-review
+description: BEAR.SundayプロジェクトのPHPコード品質を評価する。PHPMDメトリクス（CC, NPath, パラメータ数, フィールド数）とBEAR.Sunday固有の基準（リソース設計, DI, 型安全性）で評価。コードレビュー、品質チェック、リファクタリング検討時に使用。
+---
+
+# BEAR.Sunday コードレビュースキル
+
+## 評価手順
+
+### 1. PHPMDによる定量評価
+
+以下のコマンドでメトリクスを取得:
+
+```bash
+./vendor-bin/tools/vendor/bin/phpmd [ファイルパス] text codesize,design 2>/dev/null | grep -v "^Deprecated"
+```
+
+### 2. 評価基準
+
+#### Cyclomatic Complexity (CC)
+
+| 評価 | CC値 | 状態 | アクション |
+|------|------|------|-----------|
+| **A** | 1-10 | 非常に良好。シンプルでテストが容易 | 維持すべき状態 |
+| **B** | 11-20 | 許容範囲。少し複雑だがメンテナンス可能 | 複雑なロジックなら許容 |
+| **C** | 21-30 | 警告。テストが書きづらくバグが混入しやすい | リファクタリング推奨 |
+| **D** | 31+ | 失格。保守不能 | 即時対応必須 |
+
+#### NPath Complexity
+
+| 評価 | NPath | 状態 |
+|------|-------|------|
+| **A** | 1-200 | 良好 |
+| **B** | 201-500 | 許容範囲 |
+| **C** | 501-1000 | 警告 |
+| **D** | 1001+ | 失格 |
+
+#### ExcessiveParameterList
+
+| 評価 | パラメータ数 | 状態 |
+|------|-------------|------|
+| **A** | 1-10 | 良好 |
+| **B** | 11-15 | 許容範囲（DTOを検討） |
+| **C** | 16-20 | 警告（オブジェクトでラップ推奨） |
+| **D** | 21+ | 失格 |
+
+#### TooManyFields
+
+| 評価 | フィールド数 | 状態 |
+|------|-------------|------|
+| **A** | 1-15 | 良好 |
+| **B** | 16-22 | 許容範囲（分割を検討） |
+| **C** | 23-30 | 警告 |
+| **D** | 31+ | 失格 |
+
+### 3. BEAR.Sunday固有の評価
+
+#### リソース設計 (Resourceクラスのみ)
+
+| 評価 | 基準 |
+|------|------|
+| **A** | `#[Embed]`を適切に使用、単一責任、適切なHTTPメソッド |
+| **B** | 基本的なリソースパターンに従っている |
+| **C** | ロジックが肥大化、責務が曖昧 |
+| **D** | リソースでないコード（コントローラー的実装） |
+
+#### bodyへの代入パターン
+
+逐次代入ではなく、最後にまとめて構造を明示すべき。
+
+```php
+// ❌ 問題: 逐次代入（構造が見えにくい）
+$this['contentTags'] = $tags;
+$this['article'] = $article;
+$this['blogger'] = $blogger;
+$this['meta'] = $meta;
+
+// ✅ 推奨: 最後にまとめて構造を明示
+$this->body = [
+    'article' => $article,
+    'blogger' => $blogger,
+    'contentTags' => $tags,
+    'meta' => $meta,
+];
+```
+
+**利点:**
+- レスポンス構造が一目でわかる
+- プロパティの追加・削除が容易
+- コードレビューしやすい
+
+#### privateメソッドへの引数渡しパターン
+
+同じ引数を複数のprivateメソッドに渡すパターンは、リソースの責務過多を示す。
+
+```php
+// ❌ 問題: 同じ引数を何度も渡す、リソースが肥大化
+$this->setTdParams($article, $blogger->displayName ?? '', $tags);
+$this->setStructuredData($article, $meta, $blogger, $tags);
+$this->setSurrogateKey($article, $blogger);
+
+// ✅ 推奨: サービスに委譲、リソースは「何を返すか」のみ
+$this->body = [
+    'article' => $article,
+    'blogger' => $blogger,
+    'meta' => $meta,
+    'tdParams' => $this->tdParamsFactory->create($article, $blogger, $tags),
+    'structuredData' => $this->structuredDataFactory->create($article, $meta, $blogger, $tags),
+];
+$this->headers[Header::SURROGATE_KEY] = $this->surrogateKeyBuilder->build($article, $blogger);
+```
+
+**原則**: リソースは「何を返すか」を決める。「どう作るか」はサービスに任せる。
+
+#### リソース内のループ
+
+リソース内に複雑なループを書かない。ドメイン層に委譲する。
+
+```php
+// ❌ 問題: リソース内に複雑なループ
+foreach (Ranking::CATEGORIES as $key => $categorySlugArray) {
+    if ($key === self::ALL) {
+        $result = $this->article->rankingAllArticleList(...);
+    } else {
+        $result = $this->article->rankingCategoryArticleList(...);
+    }
+    foreach ($result as $item) {
+        $articleIds[] = $item['id'];
+        // ...
+    }
+    $list[$key] = new ValidRankingArticleList($result, ...);
+}
+
+// ✅ 推奨: ドメインに委譲
+$rankingCollection = $this->rankingAggregator->aggregate($limit);
+$this->body = [
+    'rankings' => $rankingCollection->lists,
+    'articleIds' => $rankingCollection->articleIds,
+];
+```
+
+#### Domain vs Service の区別
+
+| 層 | 責務 | 委譲すべきロジック |
+|---|------|-------------------|
+| **Domain** | ビジネスロジック、ルール | 集計、計算、変換、バリデーション |
+| **Service** | 外部連携、ユースケース調整 | API呼び出し、メール送信、ファイル操作 |
+| **Query** | データ取得 | SQLによるデータアクセス |
+
+```php
+// Domain: ビジネスロジック
+class RankingAggregator
+{
+    public function aggregate(array $results): RankingCollection
+}
+
+// Service: 外部連携
+class MailNotificationService
+{
+    public function notify(User $user, Article $article): void
+}
+
+// Query: データ取得
+interface RankingQueryInterface
+{
+    public function getCategoryRankings(int $limit): array;
+}
+```
+
+#### Embed未使用の検出
+
+`$this->resource->get()` で他リソースを取得して `$this->body` にセットしている場合、
+正当な理由がなければ `#[Embed]` を使用すべき。
+
+```php
+// ❌ 問題: 手続き的なリソース取得
+$user = $this->resource->get('app://self/user', ['id' => $id]);
+$this->body['user'] = $user->body;
+
+// ✅ 推奨: 宣言的なEmbed
+#[Embed(src: 'app://self/user{?id}', rel: 'user')]
+public function onGet(int $id): static
+```
+
+**例外（許容されるケース）:**
+- 条件付きで取得する場合（if文内でのget）
+- 取得結果を加工・変換する場合
+- PUT/POST/DELETE内での参照
+
+#### 戻り値の型
+
+リソースメソッド（onGet, onPost, onPut, onPatch, onDelete）は `static` を返すべき。
+
+```php
+// ✅ 正しい
+public function onGet(int $id): static
+
+// ⚠️ 動作するが推奨されない
+public function onGet(int $id): ResourceObject
+public function onGet(int $id): self
+```
+
+| 戻り値型 | 評価 |
+|----------|------|
+| `static` | OK |
+| `ResourceObject` / `self` | 推奨（staticへの変更を推奨） |
+
+#### 依存性注入
+
+| 評価 | 基準 |
+|------|------|
+| **A** | コンストラクタ注入のみ、インターフェース依存 |
+| **B** | 具象クラス依存が一部 |
+| **C** | トレイトによるセッターインジェクション、サービスロケーター混在 |
+| **D** | グローバル状態、静的メソッド依存 |
+
+#### セッターインジェクションの判定
+
+**原則**: コンストラクタインジェクションを使用すべき。
+
+```php
+// ❌ 問題: トレイトでセッターインジェクション
+trait MetaTag
+{
+    protected Article $articleMeta;
+
+    #[Inject]
+    public function setArticleMeta(Article $articleMeta): void
+    {
+        $this->articleMeta = $articleMeta;
+    }
+}
+
+// ✅ 推奨: コンストラクタインジェクション
+public function __construct(
+    private readonly Article $articleMeta,
+)
+```
+
+| パターン | 評価 |
+|----------|------|
+| コンストラクタインジェクション | ✅ 推奨 |
+| トレイトによる `#[Inject]` セッター | ❌ 問題 |
+| `use ResourceInject` | ❌ 問題（セッターインジェクション） |
+| `use AInject` 系トレイト | ❌ 問題 |
+| ResourceObject固有のセッター（`setRenderer`等） | ✅ OK（フレームワーク用） |
+
+```php
+// ❌ 問題: トレイトでリソース注入
+use ResourceInject;
+
+// ✅ 推奨: コンストラクタで注入
+public function __construct(
+    private readonly ResourceInterface $resource,
+)
+```
+
+**トレイトでのセッターインジェクションの問題点:**
+- 依存関係が隠蔽される（コンストラクタを見ても分からない）
+- テストが困難（セッターを呼ぶかリフレクションが必要）
+- 依存がミュータブル（後から変更可能）
+
+#### `new` の使用判定
+
+**重要**: `new` の使用が問題かどうかは、生成対象の種類で判断する。
+
+| 種類 | `new` 使用 | 判定基準 |
+|------|-----------|----------|
+| ドメインオブジェクト | ✅ OK | データを保持、状態を表現（Entity, ValueObject） |
+| 値オブジェクト | ✅ OK | イミュータブル、データ表現（DateTime, Money等） |
+| DTO | ✅ OK | データ転送用オブジェクト |
+| サービス | ❌ NG → DI | 振る舞いを持つ、外部依存がある |
+| リポジトリ | ❌ NG → DI | データアクセス層 |
+| HTTPクライアント | ❌ NG → DI | 外部通信 |
+
+```php
+// ✅ OK: ドメイン/値オブジェクト
+$article = new ArticleDomain($data);
+$dateTime = new DateTimeImmutable();
+$thumbnail = new Thumbnail($data);
+
+// ❌ NG: サービスはDIすべき
+$client = new HttpClient();        // → HttpClientInterface を注入
+$logger = new FileLogger();        // → LoggerInterface を注入
+$mailer = new SmtpMailer();        // → MailerInterface を注入
+```
+
+**文脈から判断すること**: クラス名、名前空間、コンストラクタ引数から種類を判定する。
+
+#### 例外の設計
+
+`@throws Exception` は問題。具体的なドメイン例外を使用すべき。
+
+| 記述 | 評価 |
+|------|------|
+| `@throws Exception` | ❌ 問題（何の例外かわからない） |
+| `@throws \Exception` | ❌ 問題 |
+| `@throws RuntimeException` | ⚠️ 広すぎる |
+| `@throws ArticleNotFoundException` | ✅ 具体的で良い |
+
+**推奨**: すべての例外は `RuntimeException` か `LogicException` を継承したドメイン例外とする。
+
+```php
+// ✅ 推奨: ドメイン例外
+class ArticleNotFoundException extends RuntimeException {}
+class InvalidArticleStateException extends LogicException {}
+
+// 使用例
+/**
+ * @throws ArticleNotFoundException 記事が見つからない場合
+ */
+public function onGet(int $id): static
+```
+
+| 基底クラス | 用途 |
+|-----------|------|
+| `RuntimeException` | 実行時に発生する回復可能なエラー（リソース不在、外部API失敗等） |
+| `LogicException` | プログラムのロジックエラー（不正な引数、不正な状態遷移等） |
+
+#### リソース内のtry-catch（ポケモンキャッチ問題）
+
+リソース内に巨大なtry-catchブロックを書かない。
+
+```php
+// ❌ 問題: 巨大なtry-catch、Throwableキャッチ
+public function onGet(int $id): static
+{
+    try {
+        // 100行以上のロジック...
+        $article = $this->article->item($id);
+        $blogger = $this->blogger->item($article['bloggerId']);
+        $meta = $this->meta->generate($article);
+        // さらに続く...
+    } catch (Throwable $e) {
+        $this->logger->error('エラー', ['exception' => $e]);
+        throw $e;
+    }
+}
+
+// ✅ 推奨: フレームワークに任せる、ロジックは委譲
+public function onGet(int $id): static
+{
+    $articleView = $this->articleViewFactory->create($id);
+
+    $this->body = [
+        'article' => $articleView->article,
+        'blogger' => $articleView->blogger,
+        'meta' => $articleView->meta,
+    ];
+
+    return $this;
+}
+```
+
+**問題点:**
+- `Throwable` や `Exception` の広範なキャッチ（何でも捕まえる「ポケモンキャッチ」）
+- tryブロックが巨大（どこでエラーが起きるか不明）
+- ログして再throwは冗長（フレームワークが処理する）
+- リソースの責務過多を示す
+
+**推奨:**
+- 例外処理はフレームワークに任せる
+- 特定の例外のみ必要な場合は小さなtry-catchで
+- ロジックはDomain/Serviceに委譲してリソースをシンプルに
+
+| パターン | 評価 |
+|----------|------|
+| try-catchなし（フレームワーク任せ） | ✅ 推奨 |
+| 特定例外の小さなcatch | ✅ OK |
+| 巨大try + `catch (Throwable)` | ❌ 問題 |
+| 巨大try + `catch (Exception)` | ❌ 問題 |
+
+#### 型安全性
+
+| 評価 | 基準 |
+|------|------|
+| **A** | 完全な型指定、ジェネリクス使用、`mixed`なし |
+| **B** | 基本的な型指定あり、一部`mixed` |
+| **C** | `array<string, mixed>`多用、`@psalm-suppress`多数 |
+| **D** | 型指定なし、`array<object>`使用 |
+
+#### DoctrineアノテーションとPHP 8属性
+
+PHP 8ではDoctrineアノテーション `/** @Embed */` ではなくネイティブ属性 `#[Embed]` を使用。
+
+| パターン | 評価 |
+|----------|------|
+| `#[Embed]`, `#[Inject]`, `#[Named]` | ✅ 推奨 |
+| `/** @Embed */`, `/** @Inject */` | ❌ レガシー |
+
+#### 定数と設定値
+
+設定値はクラス定数ではなく注入すべき。ドメイン不変値はEnumを使用。
+
+```php
+// ❌ 問題: 設定値をクラス定数に
+private const API_URL = 'https://api.example.com';
+private const LIMIT = 100;
+private const USER_ID = 456;
+
+// ✅ 推奨: NamedModuleでバインド、#[Named]で注入
+// Module:
+$this->bind()->annotatedWith('API_URL')->toInstance($apiUrl);
+
+// Resource:
+public function __construct(
+    #[Named('API_URL')] private readonly string $apiUrl,
+    #[Named('DEFAULT_LIMIT')] private readonly int $limit,
+)
+
+// ✅ ドメイン不変値はEnum
+enum ContentStatus: string {
+    case Draft = 'draft';
+    case Published = 'published';
+}
+```
+
+| 種類 | クラス定数 | 注入 |
+|------|-----------|------|
+| URL、パス、APIキー | ❌ | ✅ |
+| 制限値、タイムアウト | ❌ | ✅ |
+| ID、マジックナンバー | ❌ | ✅ |
+| ステータス、型識別子 | △ Enum推奨 | - |
+
+#### リソース内のDB直接アクセス
+
+リソースでトランザクションやSQL実行は禁止。Query層に委譲する。
+
+```php
+// ❌ 問題: リソース内でDB操作
+$this->pdo->beginTransaction();
+$this->pdo->exec($sql);
+$this->pdo->commit();
+
+// ✅ 推奨: Query層に委譲
+$this->articleQuery->createWithTransaction($data);
+```
+
+#### デバッグコード
+
+`error_log()`, `var_dump()`, `print_r()` は禁止。LoggerInterfaceを使用。
+
+```php
+// ❌ 問題
+error_log('Error: ' . $e->getMessage());
+
+// ✅ 推奨
+$this->logger->error('Error', ['exception' => $e]);
+```
+
+#### ファイルサイズ
+
+| 行数 | 評価 |
+|------|------|
+| 1-200 | ✅ 良好 |
+| 201-400 | ⚠️ 分割を検討 |
+| 401+ | ❌ 責務過多 |
+
+#### リソースメソッドの引数
+
+`array<string, mixed>` ではなく、明示的な引数またはInputクラスを使用。
+
+```php
+// ❌ 問題: マジックバッグ
+public function onGet(array $conditions): static
+
+// ✅ 推奨: 明示的なスカラー引数
+public function onGet(
+    ?int $categoryId = null,
+    ?string $keyword = null,
+): static
+
+// ✅ 推奨: Inputクラス（複雑なデータ）
+public function onPost(UserInput $user): static
+```
+
+| パラメータ数 | 推奨 |
+|-------------|------|
+| 1-10 | スカラー引数（明示的で良い） |
+| 11+ | `#[Input]` + DTOクラスを検討 |
+
+**Inputを使うべき時:**
+- 関連パラメータが概念として一体（住所、ユーザー情報等）
+- ネスト構造や配列を含む
+- 複数リソースで同じパラメータセットを使う
+
+#### Webコンテキストの取得
+
+スーパーグローバル直接アクセスは禁止。属性で取得する。
+
+```php
+// ❌ 問題: スーパーグローバル直接アクセス
+$id = $_GET['id'];
+$token = $_COOKIE['token'];
+
+// ✅ 推奨: 属性で取得（テスト容易）
+public function onGet(
+    #[QueryParam('id')] string $userId,
+    #[CookieParam('token')] string $token = '',
+): static
+```
+
+#### ResourceParam（リソース間依存）
+
+他リソースの結果を引数として注入。手続き的な取得より宣言的で推奨。
+
+```php
+// ❌ 問題: 手続き的に取得
+public function onPut(array $data): static
+{
+    $userId = $this->resource->get('app://self/user/me')['id'];
+    // ...
+}
+
+// ✅ 推奨: 宣言的に注入
+#[ResourceParam(uri: 'app://self/user/me#id', param: 'userId')]
+public function onPut(int $userId, array $data): static
+```
+
+#### ファイルアップロード
+
+`$_FILES` 直接アクセスではなく `#[UploadFiles]` を使用。
+
+```php
+// ❌ 問題
+$file = $_FILES['image'];
+
+// ✅ 推奨
+public function onPost(#[UploadFiles] array $files): static
+```
+
+#### HTTPステータスコード
+
+適切なステータスコードを返す。
+
+| 操作 | コード |
+|------|--------|
+| GET成功 | 200 OK |
+| POST成功（作成） | 201 Created |
+| 削除成功 | 204 No Content |
+| 見つからない | 404 Not Found |
+| バリデーションエラー | 400 Bad Request |
+
+#### Pageリソースの制限
+
+Pageリソースは `onGet` と `onPost` のみ使用。
+
+```php
+// ❌ 問題: PageでonPut/onDelete
+class UserPage extends ResourceObject {
+    public function onDelete(int $id): static  // NG
+}
+
+// ✅ 推奨: AppリソースでCRUD、PageはGET/POSTのみ
+```
+
+#### 継承より合成
+
+トレイトや親クラスメソッドより依存性注入で組み合わせる。
+
+```php
+// ❌ 問題: トレイトで機能追加
+use MetaTagTrait;
+use SurrogateKeyTrait;
+
+// ✅ 推奨: 依存性注入
+public function __construct(
+    private readonly MetaTagService $metaTag,
+    private readonly SurrogateKeyService $surrogateKey,
+)
+```
+
+#### Providerの回避
+
+`Provider` より `toConstructor` 束縛を優先。
+
+```php
+// ❌ 問題: Provider経由
+$this->bind(Foo::class)->toProvider(FooProvider::class);
+
+// ✅ 推奨: toConstructor束縛
+$this->bind(Foo::class)->toConstructor(Foo::class, ['arg' => 'value']);
+```
+
+#### グローバル参照禁止
+
+`define`定数、staticメソッド直接呼び出しは禁止。
+
+```php
+// ❌ 問題
+$value = SOME_CONSTANT;
+$result = SomeClass::staticMethod();
+
+// ✅ 推奨: 注入
+public function __construct(
+    #[Named('SOME_VALUE')] private readonly string $value,
+    private readonly SomeService $service,
+)
+```
+
+#### バリデーション（JsonSchema）
+
+入力バリデーションはJsonSchemaで宣言的に行う。
+
+```php
+// ❌ 問題: 手動バリデーション
+public function onPost(array $data): static
+{
+    if (empty($data['title'])) {
+        throw new InvalidArgumentException();
+    }
+    // ...
+}
+
+// ✅ 推奨: JsonSchemaで宣言
+#[JsonSchema(schema: 'article.post.json')]
+public function onPost(string $title, string $body): static
+```
+
+```json
+// var/json_schema/article.post.json
+{
+  "type": "object",
+  "required": ["title", "body"],
+  "properties": {
+    "title": {"type": "string", "minLength": 1, "maxLength": 255},
+    "body": {"type": "string", "minLength": 1}
+  }
+}
+```
+
+#### AOP（インターセプター）
+
+横断的関心事はインターセプターで分離。リソースに直接書かない。
+
+```php
+// ❌ 問題: リソースに横断的関心事
+public function onPost(array $data): static
+{
+    $this->logger->info('Creating article');
+    $start = microtime(true);
+    // ビジネスロジック
+    $this->logger->info('Created', ['time' => microtime(true) - $start]);
+}
+
+// ✅ 推奨: インターセプターで分離
+// Module:
+$this->bindInterceptor(
+    $this->matcher->subclassesOf(ResourceObject::class),
+    $this->matcher->startsWith('on'),
+    [LogInterceptor::class]
+);
+```
+
+| 用途 | 実装場所 |
+|------|---------|
+| ロギング | インターセプター |
+| トランザクション | インターセプター |
+| 認証チェック | インターセプター |
+| キャッシュ | `#[Cacheable]` |
+| バリデーション | `#[JsonSchema]` |
+
+#### 認証・認可
+
+認証はインターセプターまたはミドルウェアで。リソース内に認証ロジックを書かない。
+
+```php
+// ❌ 問題: リソース内で認証チェック
+public function onGet(int $id): static
+{
+    if (!$this->auth->isLoggedIn()) {
+        $this->code = 401;
+        return $this;
+    }
+    // ...
+}
+
+// ✅ 推奨: アトリビュート + インターセプター
+#[RequireLogin]
+public function onGet(int $id): static
+
+// ✅ 推奨: ロールベース
+#[RequireRole('admin')]
+public function onDelete(int $id): static
+```
+
+| パターン | 評価 |
+|----------|------|
+| カスタム属性 + インターセプター | ✅ 推奨 |
+| ミドルウェア | ✅ 推奨 |
+| リソース内で直接チェック | ❌ 問題 |
+
+## 出力フォーマット
+
+```
+## ファイル評価: [ファイルパス]
+
+### PHPMDメトリクス
+
+| メトリクス | 値 | 評価 |
+|-----------|-----|------|
+| Cyclomatic Complexity | X | A/B/C/D |
+| NPath Complexity | X | A/B/C/D |
+| Parameters | X | A/B/C/D |
+| Fields | X | A/B/C/D |
+
+### BEAR.Sunday固有評価
+
+| 項目 | 評価 | コメント |
+|------|------|----------|
+| リソース設計 | A/B/C/D | ... |
+| body代入 | OK/問題あり | 逐次代入ではなくまとめて構造を明示 |
+| Embed使用 | OK/問題あり | resource->get()でbodyにセットしていないか |
+| 戻り値型 | OK/推奨 | static を使用しているか |
+| 依存性注入 | A/B/C/D | ... |
+| 例外設計 | OK/問題あり | @throws Exception は問題、ドメイン例外を使用 |
+| try-catch | OK/問題あり | 巨大try-catch、Throwable/Exceptionキャッチは問題 |
+| 型安全性 | A/B/C/D | ... |
+
+### 総合評価: [A/B/C/D]
+
+### 改善提案
+
+1. ...
+2. ...
+```
+
+## 参考資料
+
+- [BEAR.Sunday 1ページ版](https://bearsunday.github.io/llms-full.txt)
+- [リソース](https://bearsunday.github.io/manuals/1.0/ja/resource.html)
+- [リソースパラメーター](https://bearsunday.github.io/manuals/1.0/ja/resource_param.html)
+- [DI](https://bearsunday.github.io/manuals/1.0/ja/di.html)
+- [AOP](https://bearsunday.github.io/manuals/1.0/ja/aop.html)
+- [バリデーション](https://bearsunday.github.io/manuals/1.0/ja/validation.html)
+- [データベース](https://bearsunday.github.io/manuals/1.0/ja/database.html)
+- [コーディングガイド](https://bearsunday.github.io/manuals/1.0/ja/coding-guide.html)
+- [PHPMD Code Size Rules](https://phpmd.org/rules/codesize.html)

--- a/.claude/skills/fix-return-static/SKILL.md
+++ b/.claude/skills/fix-return-static/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: fix-return-static
+description: ResourceクラスのResourceObject戻り値型をstaticに一括変換する。BEAR.Sundayのモダンな記法への移行時に使用。
+---
+
+# ResourceObject → static 一括変換スキル
+
+## 概要
+
+BEAR.Sundayリソースクラスの戻り値型 `ResourceObject` を `static` に変換する。
+
+## 変換対象
+
+```php
+// 変換前
+public function onGet(): ResourceObject
+public function onPost(string $name): ResourceObject
+public function onPut(int $id): ResourceObject
+public function onPatch(int $id): ResourceObject
+public function onDelete(int $id): ResourceObject
+
+// 変換後
+public function onGet(): static
+public function onPost(string $name): static
+public function onPut(int $id): static
+public function onPatch(int $id): static
+public function onDelete(int $id): static
+```
+
+## 実行手順
+
+### 1. 対象ファイルの確認
+
+```bash
+grep -r "): ResourceObject" src/Resource --include="*.php" | wc -l
+```
+
+### 2. 一括変換の実行
+
+```bash
+find src/Resource -name "*.php" -exec sed -i '' 's/): ResourceObject/): static/g' {} +
+```
+
+### 3. 不要なuse文の削除
+
+変換後、`use BEAR\Resource\ResourceObject;` が戻り値型のためだけに使われていた場合は削除する。
+
+```bash
+# 確認（ResourceObjectが他で使われていないファイル）
+grep -l "use BEAR\\\\Resource\\\\ResourceObject;" src/Resource --include="*.php" | while read f; do
+  if ! grep -q "extends ResourceObject" "$f"; then
+    echo "$f"
+  fi
+done
+```
+
+### 4. コーディング規約の適用
+
+```bash
+composer cs-fix
+```
+
+### 5. テストの実行
+
+```bash
+composer test
+```
+
+## 注意事項
+
+- `extends ResourceObject` は変更しない（クラス継承は維持）
+- テストが通ることを確認してからコミット
+- 大量の変更になるため、専用ブランチで作業推奨

--- a/.claude/skills/sql-quality/SKILL.md
+++ b/.claude/skills/sql-quality/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sql-quality
+description: Koriym.SqlQualityを使用してSQLクエリの性能問題を検出・改善する。フルテーブルスキャン、非効率なJOIN、インデックス無効化を検出。
+---
+
+# SQL品質改善スキル
+
+## 概要
+
+[Koriym.SqlQuality](https://github.com/koriym/Koriym.SqlQuality)を使用してMySQLクエリを分析し、性能問題を検出・改善する。
+
+## 検出可能な問題
+
+| 問題 | 説明 |
+|------|------|
+| フルテーブルスキャン | インデックスを使用せず全行走査 |
+| 非効率なJOIN | 適切なインデックスがないJOIN |
+| インデックス無効化 | 関数使用によるインデックス無効化 |
+
+## 使い方
+
+### 1. インストール
+
+```bash
+composer require koriym/sql-quality --dev
+```
+
+### 2. SQLファイルの分析
+
+```bash
+vendor/bin/sql-quality analyze var/sql/
+```
+
+### 3. 出力の確認
+
+**クエリ分析リスト:**
+- 各クエリのコスト
+- パフォーマンスレベル
+- 検出された問題
+
+**オプティマイザー影響分析:**
+- オプティマイザー有効/無効時の比較
+- コスト削減率
+
+## 改善パターン
+
+### インデックス無効化の回避
+
+```sql
+-- ❌ 問題: 関数でインデックス無効化
+SELECT * FROM articles WHERE YEAR(created_at) = 2024;
+
+-- ✅ 推奨: 範囲指定
+SELECT * FROM articles
+WHERE created_at >= '2024-01-01' AND created_at < '2025-01-01';
+```
+
+### LIKEの前方一致
+
+```sql
+-- ❌ 問題: 前方ワイルドカード
+SELECT * FROM users WHERE name LIKE '%田中';
+
+-- ✅ 推奨: 後方ワイルドカード（インデックス使用可能）
+SELECT * FROM users WHERE name LIKE '田中%';
+```
+
+### JOINの最適化
+
+```sql
+-- ❌ 問題: インデックスなしのJOIN
+SELECT * FROM orders o
+JOIN order_items oi ON o.id = oi.order_id;  -- order_idにインデックスがない
+
+-- ✅ 推奨: インデックス追加
+ALTER TABLE order_items ADD INDEX idx_order_id (order_id);
+```
+
+### SELECT *の回避
+
+```sql
+-- ❌ 問題: 全カラム取得
+SELECT * FROM articles WHERE id = 1;
+
+-- ✅ 推奨: 必要なカラムのみ
+SELECT id, title, body FROM articles WHERE id = 1;
+```
+
+## BEAR.Sundayとの連携
+
+### SQLファイルの配置
+
+```
+var/
+└── sql/
+    └── Article/
+        ├── item.sql
+        ├── list.sql
+        └── search.sql
+```
+
+### Queryクラスでの使用
+
+```php
+interface ArticleQueryInterface
+{
+    #[Query('Article/item.sql')]
+    public function item(int $id): ?array;
+}
+```
+
+### CI/CDでの自動チェック
+
+```yaml
+# .github/workflows/sql-quality.yml
+- name: SQL Quality Check
+  run: vendor/bin/sql-quality analyze var/sql/
+```
+
+## 参考資料
+
+- [Koriym.SqlQuality](https://github.com/koriym/Koriym.SqlQuality)
+- [MySQL EXPLAIN](https://dev.mysql.com/doc/refman/8.0/en/explain.html)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # BEAR.Skills
-Claude Skills for BEAR.Sunday
+
+Claude Code skills for BEAR.Sunday framework development.
+
+## Skills
+
+### bear-review
+
+Code quality evaluation using PHPMD metrics and BEAR.Sunday-specific patterns.
+
+**Evaluates:**
+- PHPMD metrics (Cyclomatic Complexity, NPath, Parameters, Fields)
+- Resource design (Embed usage, body assignment, loop delegation)
+- Dependency injection (constructor injection, trait prohibition)
+- Type safety, exception design, try-catch patterns
+- PHP 8 attributes, validation, AOP, authentication
+
+### bear-hypermedia
+
+Add `#[Link]` attributes to resources and implement HyperMedia tests.
+
+**Features:**
+- Analyze resources and add appropriate `#[Link]` declarations
+- Generate HyperMedia tests that express use cases as workflows
+- Generate ALPS profiles from resource classes
+
+### bear-resource-test
+
+Generate smoke test dataProvider for all resources.
+
+**Features:**
+- Scan resource classes and extract method signatures
+- Generate dataProvider with method, URI, query, expected code
+- Single test class tests all resources
+
+### bear-cache-strategy
+
+Add cache attributes to resources.
+
+**Features:**
+- Detect resources without cache declarations
+- Classify as content API or computation API
+- Apply appropriate `#[Cacheable]`, `#[DonutCache]`, or TTL-based caching
+
+### fix-return-static
+
+Bulk convert `ResourceObject` return types to `static`.
+
+**Usage:**
+```bash
+find src/Resource -name "*.php" -exec sed -i '' 's/): ResourceObject/): static/g' {} +
+```
+
+### sql-quality
+
+SQL performance analysis using [Koriym.SqlQuality](https://github.com/koriym/Koriym.SqlQuality).
+
+**Detects:**
+- Full table scans
+- Inefficient JOINs
+- Index invalidation by functions
+
+## Installation
+
+Copy `.claude/skills/` to your project's `.claude/` directory.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

BEAR.Sundayプロジェクト向けのコード品質評価・開発支援スキルを追加します。

### 追加スキル

| スキル | 種類 | 目的 |
|--------|------|------|
| **bear-review** | レビュー | PHPMDメトリクスとBEAR.Sunday固有基準でコード品質を評価 |
| **bear-hypermedia** | 作成 | #[Link]追加、HyperMediaテスト、ALPS生成 |
| **bear-resource-test** | 作成 | スモークテストdataProvider生成 |
| **bear-cache-strategy** | 作成 | リソースにキャッシュ属性を追加 |
| **fix-return-static** | 作成 | ResourceObject→static一括変換 |
| **sql-quality** | 改善 | Koriym.SqlQualityでSQL性能分析 |

### bear-reviewでカバーする項目

- PHPMDメトリクス（CC, NPath, パラメータ数, フィールド数）
- リソース設計（Embed, body代入, ループ委譲）
- DI（コンストラクタ注入, トレイト禁止）
- 型安全性、例外設計、try-catch
- PHP 8属性、定数注入、バリデーション、AOP、認証

## Test plan

- [ ] 各スキルのSKILL.mdが正しいフォーマットか確認
- [ ] スキルがClaude Codeで認識されるか確認