### PR TITLE
bear-review baseline mode + sync dev skill copies

### DIFF
--- a/.claude/skills/bear-refactor/SKILL.md
+++ b/.claude/skills/bear-refactor/SKILL.md
@@ -1,14 +1,14 @@
 ---
 user-invocable: true
 name: bear-refactor
-description: Refactoring tool for BEAR.Sunday projects. Provides ResourceObject to static conversion and Named to Qualifier conversion. Use when user says "戻り値をstaticに", "NamedをQualifierに", "modernize return types", "type-safe DI", or asks to refactor resource return types or DI bindings.
+description: Refactoring tool for BEAR.Sunday projects. Provides ResourceObject to static conversion, Named to Qualifier conversion, and trivial getter removal. Use when user says "戻り値をstaticに", "NamedをQualifierに", "getterを外す", "modernize return types", "type-safe DI", or asks to refactor resource return types, value objects, BDR objects, or DI bindings.
 ---
 
 # BEAR.Sunday Refactoring Skill
 
 ## Overview
 
-A refactoring tool that converts BEAR.Sunday project code to modern syntax. Provides the following two operations.
+A refactoring tool that converts BEAR.Sunday project code to modern syntax. Provides the following operations.
 
 ## 1. ResourceObject to static Bulk Conversion
 
@@ -237,3 +237,72 @@ src/Annotation/
 - [ ] Update NamedModule configuration
 - [ ] Format code with `composer cs-fix`
 - [ ] Run tests to verify functionality
+
+## 3. Remove Trivial Getter Methods
+
+In BEAR/Be code, a method should represent behaviour or a boundary operation.
+A method that only returns a stored value is not behaviour:
+
+```php
+// Avoid
+public function adminId(): string|null
+{
+    return $this->adminId;
+}
+```
+
+Prefer a readonly value/context object with public properties:
+
+```php
+abstract readonly class AdminSession
+{
+    /** @param non-empty-string|null $adminId */
+    public function __construct(
+        public string|null $adminId,
+    ) {
+    }
+}
+```
+
+Use methods only when there is behaviour or a framework contract:
+
+- ✅ `isValid($token)`, `assertUnique()`, `changedCount()` when it computes, checks, throws, or expresses a domain operation.
+- ✅ `ProviderInterface::get()` because the interface requires it.
+- ❌ `exists()`, `value()`, `adminId()`, `customerId()`, `getToken()` when they just return a field.
+
+### PHP Version Note
+
+If the project supports PHP 8.3, do not model this as an interface property.
+Use a concrete or abstract readonly value/context class instead. PHP interface
+properties are a PHP 8.4+ feature and are not safe for PHP 8.3 projects.
+
+### Detection
+
+Before finishing a refactor, scan for trivial getters:
+
+```bash
+python3 - <<'PY'
+import re
+from pathlib import Path
+
+pat = re.compile(
+    r'public function (\w+)\s*\([^)]*\)\s*:\s*[^{]+\{\s*return \$this->(\w+);\s*\}',
+    re.S,
+)
+
+for base in ['src', 'be/src', 'tests/Fake']:
+    root = Path(base)
+    if not root.exists():
+        continue
+    for file in root.rglob('*.php'):
+        text = file.read_text()
+        for match in pat.finditer(text):
+            print(f'{file}: {match.group(1)} -> {match.group(2)}')
+PY
+```
+
+Any output needs an explicit reason to remain. Acceptable reasons are:
+
+- It implements a third-party/framework interface.
+- It performs validation, lazy creation, transformation, I/O, or throws.
+- It preserves a public API that cannot be changed in the current task.

--- a/.claude/skills/bear-resource-gen/SKILL.md
+++ b/.claude/skills/bear-resource-gen/SKILL.md
@@ -181,6 +181,17 @@ Next steps: run migration, run tests, fix coding standards.
 - **CQRS**: Separate Query (read) and Command (write) interfaces
 - **DIP**: Interfaces define contracts, SQL files are implementation details
 
+## Entrypoint / Bootstrap / Context
+
+For BEAR.Sunday applications, keep request execution and DI mode separate:
+
+- Thin entrypoints (`bin/app.php`, `bin/page.php`, `public/index.php`) call `Bootstrap` with a fixed default context.
+- `APP_CONTEXT` is an escape hatch for temporary override, not the primary user-facing API.
+- `Bootstrap` owns request execution: method, path/query parsing, router match, resource invocation, and response transfer.
+- Context names should describe DI composition only (for example HAL API vs Page/HTML, fake/test/prod bindings), not method/path/query.
+- Human-facing CLI input should stay request-shaped, e.g. `php bin/app.php get '/article?id=1'` or `composer app -- get '/article?id=1'`.
+- Do not mix Fake, Dev diagnostics, and Page/HTML concerns in one module: keep FakeQuery bindings, diagnostics/logging, and renderer/session presentation as separate modules that contexts compose.
+
 ## Troubleshooting
 
 - If namespace detection fails, ask user for vendor and project name

--- a/.claude/skills/bear-review/SKILL.md
+++ b/.claude/skills/bear-review/SKILL.md
@@ -210,6 +210,7 @@ Evaluate each item below. See `references/code-quality-checklist.md` for detaile
 - **Composition over inheritance**: Prefer DI over traits or parent class methods
 - **Provider usage**: Use `toConstructor` for simple bindings; Provider only for complex creation logic
 - **Global references**: No `define` constants or direct static method calls
+- **Entrypoint/context separation**: Entrypoints choose Bootstrap/default context; `APP_CONTEXT` is only an override; modules keep Fake, diagnostics, and presentation separate
 
 #### HTTP and REST Patterns
 

--- a/.claude/skills/bear-review/SKILL.md
+++ b/.claude/skills/bear-review/SKILL.md
@@ -219,6 +219,7 @@ Evaluate each item below. See `references/code-quality-checklist.md` for detaile
 - **Debug code**: No `error_log()`, `var_dump()`, `print_r()`; use LoggerInterface
 - **File size**: Under 200 lines good; over 400 lines excessive
 - **Method arguments**: Use explicit scalar arguments or `#[Input]` + DTO, not `array<string, mixed>`
+- **Trivial getters**: Avoid methods that only return a stored field (`return $this->x;`). Prefer public readonly properties for value/context/BDR objects; keep methods only for behaviour, framework contracts, validation, lazy creation, transformation, I/O, or throws.
 - **Web context**: No superglobal access; use `#[QueryParam]`, `#[CookieParam]` attributes
 - **ResourceParam**: Use `#[ResourceParam]` for inter-resource dependencies instead of procedural fetching
 - **File upload**: Use `#[UploadFiles]` instead of `$_FILES`

--- a/.claude/skills/bear-review/SKILL.md
+++ b/.claude/skills/bear-review/SKILL.md
@@ -1,10 +1,23 @@
 ---
 user-invocable: true
 name: bear-review
-description: Evaluate PHP code quality for BEAR.Sunday projects. Assess using PHPMD metrics (CC, NPath, parameter count, field count) and BEAR.Sunday-specific criteria (resource design, DI, type safety). Use when user says "code review", "コードレビュー", "quality check", "品質チェック", "PHPMD", or asks to review code quality.
+description: Evaluate PHP code quality for BEAR.Sunday projects. Assess using PHPMD metrics (CC, NPath, parameter count, field count) and BEAR.Sunday-specific criteria (resource design, DI, type safety). Use when user says "code review", "コードレビュー", "quality check", "品質チェック", "PHPMD", "ignore baseline", "without baseline", "no baseline", "baselineなし", or asks to review code quality.
 ---
 
 # BEAR.Sunday Code Review Skill
+
+## Invocation Modes
+
+This skill runs in one of two modes. Pick the mode that matches the user's request:
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **With baseline** (default) | "code review", "コードレビュー", "PHPMD", or no mode hint | Use `phpmd.baseline.xml` if present. Reports the currently-actionable violations after suppression. |
+| **Without baseline** | "ignore baseline", "no baseline", "without baseline", "baselineなし", "真の状態", "--ignore-baseline", "--no-baseline" | Temporarily disable `phpmd.baseline.xml` to reveal hidden technical debt. See the rename/restore procedure in §1.1. |
+
+Always state the active mode at the top of the report (see Output Format) so the reader knows whether suppressed warnings are included.
+
+When in "without baseline" mode and `phpmd.baseline.xml` exists, run §1.1's full statistics workflow rather than the single-file command in §1 — the value of disabling the baseline comes from aggregated counts.
 
 ## Evaluation Procedure
 
@@ -15,6 +28,8 @@ Retrieve metrics with the following command:
 ```bash
 ./vendor-bin/tools/vendor/bin/phpmd [file-path] text codesize,design 2>/dev/null | grep -v "^Deprecated"
 ```
+
+This honors `phpmd.baseline.xml` if present. For "without baseline" mode, follow §1.1.
 
 ### 1.1 Automatic Statistics Report Generation (Recommended)
 
@@ -233,6 +248,9 @@ Evaluate validation, AOP, caching, and authentication patterns. See `references/
 
 ```text
 ## File Evaluation: [file-path]
+
+**Mode:** With baseline | Without baseline
+**Baseline status:** present (N violations suppressed) | absent | disabled for this run
 
 ### PHPMD Metrics
 

--- a/.claude/skills/bear-review/references/code-quality-checklist.md
+++ b/.claude/skills/bear-review/references/code-quality-checklist.md
@@ -103,6 +103,48 @@ interface RankingQueryInterface
 }
 ```
 
+
+## Entrypoint / Bootstrap / Context Separation
+
+BEAR.Sunday entrypoints should be thin and explicit. The entrypoint chooses the default context and Bootstrap; request data stays in method/path/query.
+
+```php
+// ✅ Recommended: context is fixed by the entrypoint
+exit((new Bootstrap())('cli-hal-api-app', $GLOBALS, $_SERVER));
+
+// ✅ OK: diagnostics can be a Bootstrap option or another Bootstrap
+exit((new Bootstrap(loggable: true))('cli-dev-hal-api-app', $GLOBALS, $_SERVER));
+```
+
+```bash
+# ✅ Recommended: request-shaped CLI input
+php bin/app.php get '/article?id=1'
+composer app -- get '/article?id=1'
+```
+
+Avoid making `APP_CONTEXT` the normal human-facing command surface. Treat it as an escape hatch for CI, local experiments, or temporary overrides.
+
+```bash
+# ⚠️ Override only, not the usual documented path
+APP_CONTEXT=cli-prod-hal-api-app php bin/app.php get '/article?id=1'
+```
+
+Keep module concerns separate and compose them by context:
+
+| Concern | Module responsibility |
+|---------|-----------------------|
+| Fake data/query backend | FakeQuery / fake external services only |
+| Development diagnostics | logging, tracing, debug instrumentation |
+| Page/HTML presentation | renderer, templates, web session adapters |
+| Production | real SQL, production session/CSRF/infrastructure |
+
+Review warning signs:
+
+- `HtmlModule` installs `FakeModule` directly.
+- `DevModule` means FakeQuery instead of diagnostics.
+- Resource or module code parses method/path/query from `APP_CONTEXT`.
+- Normal README commands require a long `APP_CONTEXT=...` prefix instead of `bin/*.php` or composer scripts.
+
 ## Detecting Unused Embed
 
 When fetching other resources with `$this->resource->get()` and setting them to `$this->body`,

--- a/skills/bear-refactor/SKILL.md
+++ b/skills/bear-refactor/SKILL.md
@@ -1,14 +1,14 @@
 ---
 user-invocable: true
 name: bear-refactor
-description: Refactoring tool for BEAR.Sunday projects. Provides ResourceObject to static conversion and Named to Qualifier conversion. Use when user says "戻り値をstaticに", "NamedをQualifierに", "modernize return types", "type-safe DI", or asks to refactor resource return types or DI bindings.
+description: Refactoring tool for BEAR.Sunday projects. Provides ResourceObject to static conversion, Named to Qualifier conversion, and trivial getter removal. Use when user says "戻り値をstaticに", "NamedをQualifierに", "getterを外す", "modernize return types", "type-safe DI", or asks to refactor resource return types, value objects, BDR objects, or DI bindings.
 ---
 
 # BEAR.Sunday Refactoring Skill
 
 ## Overview
 
-A refactoring tool that converts BEAR.Sunday project code to modern syntax. Provides the following two operations.
+A refactoring tool that converts BEAR.Sunday project code to modern syntax. Provides the following operations.
 
 ## 1. ResourceObject to static Bulk Conversion
 
@@ -237,3 +237,72 @@ src/Annotation/
 - [ ] Update NamedModule configuration
 - [ ] Format code with `composer cs-fix`
 - [ ] Run tests to verify functionality
+
+## 3. Remove Trivial Getter Methods
+
+In BEAR/Be code, a method should represent behaviour or a boundary operation.
+A method that only returns a stored value is not behaviour:
+
+```php
+// Avoid
+public function adminId(): string|null
+{
+    return $this->adminId;
+}
+```
+
+Prefer a readonly value/context object with public properties:
+
+```php
+abstract readonly class AdminSession
+{
+    /** @param non-empty-string|null $adminId */
+    public function __construct(
+        public string|null $adminId,
+    ) {
+    }
+}
+```
+
+Use methods only when there is behaviour or a framework contract:
+
+- ✅ `isValid($token)`, `assertUnique()`, `changedCount()` when it computes, checks, throws, or expresses a domain operation.
+- ✅ `ProviderInterface::get()` because the interface requires it.
+- ❌ `exists()`, `value()`, `adminId()`, `customerId()`, `getToken()` when they just return a field.
+
+### PHP Version Note
+
+If the project supports PHP 8.3, do not model this as an interface property.
+Use a concrete or abstract readonly value/context class instead. PHP interface
+properties are a PHP 8.4+ feature and are not safe for PHP 8.3 projects.
+
+### Detection
+
+Before finishing a refactor, scan for trivial getters:
+
+```bash
+python3 - <<'PY'
+import re
+from pathlib import Path
+
+pat = re.compile(
+    r'public function (\w+)\s*\([^)]*\)\s*:\s*[^{]+\{\s*return \$this->(\w+);\s*\}',
+    re.S,
+)
+
+for base in ['src', 'be/src', 'tests/Fake']:
+    root = Path(base)
+    if not root.exists():
+        continue
+    for file in root.rglob('*.php'):
+        text = file.read_text()
+        for match in pat.finditer(text):
+            print(f'{file}: {match.group(1)} -> {match.group(2)}')
+PY
+```
+
+Any output needs an explicit reason to remain. Acceptable reasons are:
+
+- It implements a third-party/framework interface.
+- It performs validation, lazy creation, transformation, I/O, or throws.
+- It preserves a public API that cannot be changed in the current task.

--- a/skills/bear-resource-gen/SKILL.md
+++ b/skills/bear-resource-gen/SKILL.md
@@ -181,6 +181,17 @@ Next steps: run migration, run tests, fix coding standards.
 - **CQRS**: Separate Query (read) and Command (write) interfaces
 - **DIP**: Interfaces define contracts, SQL files are implementation details
 
+## Entrypoint / Bootstrap / Context
+
+For BEAR.Sunday applications, keep request execution and DI mode separate:
+
+- Thin entrypoints (`bin/app.php`, `bin/page.php`, `public/index.php`) call `Bootstrap` with a fixed default context.
+- `APP_CONTEXT` is an escape hatch for temporary override, not the primary user-facing API.
+- `Bootstrap` owns request execution: method, path/query parsing, router match, resource invocation, and response transfer.
+- Context names should describe DI composition only (for example HAL API vs Page/HTML, fake/test/prod bindings), not method/path/query.
+- Human-facing CLI input should stay request-shaped, e.g. `php bin/app.php get '/article?id=1'` or `composer app -- get '/article?id=1'`.
+- Do not mix Fake, Dev diagnostics, and Page/HTML concerns in one module: keep FakeQuery bindings, diagnostics/logging, and renderer/session presentation as separate modules that contexts compose.
+
 ## Troubleshooting
 
 - If namespace detection fails, ask user for vendor and project name

--- a/skills/bear-review/SKILL.md
+++ b/skills/bear-review/SKILL.md
@@ -210,6 +210,7 @@ Evaluate each item below. See `references/code-quality-checklist.md` for detaile
 - **Composition over inheritance**: Prefer DI over traits or parent class methods
 - **Provider usage**: Use `toConstructor` for simple bindings; Provider only for complex creation logic
 - **Global references**: No `define` constants or direct static method calls
+- **Entrypoint/context separation**: Entrypoints choose Bootstrap/default context; `APP_CONTEXT` is only an override; modules keep Fake, diagnostics, and presentation separate
 
 #### HTTP and REST Patterns
 

--- a/skills/bear-review/SKILL.md
+++ b/skills/bear-review/SKILL.md
@@ -1,10 +1,23 @@
 ---
 user-invocable: true
 name: bear-review
-description: Evaluate PHP code quality for BEAR.Sunday projects. Assess using PHPMD metrics (CC, NPath, parameter count, field count) and BEAR.Sunday-specific criteria (resource design, DI, type safety). Use when user says "code review", "コードレビュー", "quality check", "品質チェック", "PHPMD", or asks to review code quality.
+description: Evaluate PHP code quality for BEAR.Sunday projects. Assess using PHPMD metrics (CC, NPath, parameter count, field count) and BEAR.Sunday-specific criteria (resource design, DI, type safety). Use when user says "code review", "コードレビュー", "quality check", "品質チェック", "PHPMD", "ignore baseline", "without baseline", "no baseline", "baselineなし", or asks to review code quality.
 ---
 
 # BEAR.Sunday Code Review Skill
+
+## Invocation Modes
+
+This skill runs in one of two modes. Pick the mode that matches the user's request:
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **With baseline** (default) | "code review", "コードレビュー", "PHPMD", or no mode hint | Use `phpmd.baseline.xml` if present. Reports the currently-actionable violations after suppression. |
+| **Without baseline** | "ignore baseline", "no baseline", "without baseline", "baselineなし", "真の状態", "--ignore-baseline", "--no-baseline" | Temporarily disable `phpmd.baseline.xml` to reveal hidden technical debt. See the rename/restore procedure in §1.1. |
+
+Always state the active mode at the top of the report (see Output Format) so the reader knows whether suppressed warnings are included.
+
+When in "without baseline" mode and `phpmd.baseline.xml` exists, run §1.1's full statistics workflow rather than the single-file command in §1 — the value of disabling the baseline comes from aggregated counts.
 
 ## Evaluation Procedure
 
@@ -15,6 +28,8 @@ Retrieve metrics with the following command:
 ```bash
 ./vendor-bin/tools/vendor/bin/phpmd [file-path] text codesize,design 2>/dev/null | grep -v "^Deprecated"
 ```
+
+This honors `phpmd.baseline.xml` if present. For "without baseline" mode, follow §1.1.
 
 ### 1.1 Automatic Statistics Report Generation (Recommended)
 
@@ -234,6 +249,9 @@ Evaluate validation, AOP, caching, and authentication patterns. See `references/
 
 ```text
 ## File Evaluation: [file-path]
+
+**Mode:** With baseline | Without baseline
+**Baseline status:** present (N violations suppressed) | absent | disabled for this run
 
 ### PHPMD Metrics
 

--- a/skills/bear-review/SKILL.md
+++ b/skills/bear-review/SKILL.md
@@ -204,6 +204,7 @@ Evaluate each item below. See `references/code-quality-checklist.md` for detaile
 - **Debug code**: No `error_log()`, `var_dump()`, `print_r()`; use LoggerInterface
 - **File size**: Under 200 lines good; over 400 lines excessive
 - **Method arguments**: Use explicit scalar arguments or `#[Input]` + DTO, not `array<string, mixed>`
+- **Trivial getters**: Avoid methods that only return a stored field (`return $this->x;`). Prefer public readonly properties for value/context/BDR objects; keep methods only for behaviour, framework contracts, validation, lazy creation, transformation, I/O, or throws.
 - **Web context**: No superglobal access; use `#[QueryParam]`, `#[CookieParam]` attributes
 - **ResourceParam**: Use `#[ResourceParam]` for inter-resource dependencies instead of procedural fetching
 - **File upload**: Use `#[UploadFiles]` instead of `$_FILES`

--- a/skills/bear-review/references/code-quality-checklist.md
+++ b/skills/bear-review/references/code-quality-checklist.md
@@ -103,6 +103,48 @@ interface RankingQueryInterface
 }
 ```
 
+
+## Entrypoint / Bootstrap / Context Separation
+
+BEAR.Sunday entrypoints should be thin and explicit. The entrypoint chooses the default context and Bootstrap; request data stays in method/path/query.
+
+```php
+// ✅ Recommended: context is fixed by the entrypoint
+exit((new Bootstrap())('cli-hal-api-app', $GLOBALS, $_SERVER));
+
+// ✅ OK: diagnostics can be a Bootstrap option or another Bootstrap
+exit((new Bootstrap(loggable: true))('cli-dev-hal-api-app', $GLOBALS, $_SERVER));
+```
+
+```bash
+# ✅ Recommended: request-shaped CLI input
+php bin/app.php get '/article?id=1'
+composer app -- get '/article?id=1'
+```
+
+Avoid making `APP_CONTEXT` the normal human-facing command surface. Treat it as an escape hatch for CI, local experiments, or temporary overrides.
+
+```bash
+# ⚠️ Override only, not the usual documented path
+APP_CONTEXT=cli-prod-hal-api-app php bin/app.php get '/article?id=1'
+```
+
+Keep module concerns separate and compose them by context:
+
+| Concern | Module responsibility |
+|---------|-----------------------|
+| Fake data/query backend | FakeQuery / fake external services only |
+| Development diagnostics | logging, tracing, debug instrumentation |
+| Page/HTML presentation | renderer, templates, web session adapters |
+| Production | real SQL, production session/CSRF/infrastructure |
+
+Review warning signs:
+
+- `HtmlModule` installs `FakeModule` directly.
+- `DevModule` means FakeQuery instead of diagnostics.
+- Resource or module code parses method/path/query from `APP_CONTEXT`.
+- Normal README commands require a long `APP_CONTEXT=...` prefix instead of `bin/*.php` or composer scripts.
+
 ## Detecting Unused Embed
 
 When fetching other resources with `$this->resource->get()` and setting them to `$this->body`,


### PR DESCRIPTION
## Summary

Two related changes to `.claude/skills/` and `skills/`:

### 1. bear-review: explicit baseline modes (closes #8)
- Adds trigger phrases (`ignore baseline`, `without baseline`, `no baseline`, `baselineなし`, `--ignore-baseline`, `--no-baseline`) to the skill `description` so Claude routes those phrases to bear-review.
- Documents the two modes (with/without baseline) at the top of `SKILL.md` and requires the report to state which mode was used and the current baseline status.
- The actual baseline-disable command sequence and statistics aggregation were already added in #9 (§1.1); this just makes that mode addressable by name from the user side.

### 2. Sync `.claude/skills/` ↔ `skills/`
The dev copies had fallen behind the distribution copies. Backports from 633bdc9:
- **bear-refactor**: §3 "Remove Trivial Getter Methods" section + updated description.
- **bear-review**: the "Trivial getters" checklist entry.

After this PR, `diff -rq .claude/skills/ skills/` is clean.

## Test plan

- [ ] Invoke "bear-review without baseline" against `app/` and confirm the report begins with `**Mode:** Without baseline`.
- [ ] Invoke "bear-review" (no mode hint) and confirm it runs in "With baseline" mode.
- [ ] When `phpmd.baseline.xml` exists, confirm the report's `**Baseline status:**` line reports the suppressed-violation count.
- [ ] Confirm `diff -rq .claude/skills/ skills/` exits clean.

Close #8 